### PR TITLE
Fix: Ensure .txt files are included in package distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include requirements.txt
 include VERSION
+recursive-include audiolab *.txt

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ setup(
     url="https://github.com/pengzhendong/audiolab",
     packages=find_packages(),
     include_package_data=True,
+    package_data={
+        "audiolab": ["reader/templates/*.txt"],
+    },
     install_requires=requirements,
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Fixes `jinja2.exceptions.TemplateNotFound: 'filter.txt'` caused by missing template file in package distribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the distribution package to bundle additional text-based resources. This update ensures that all necessary text assets and supporting files are automatically included during installation, providing a more complete and reliable end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->